### PR TITLE
HtmlParser: Prevent infinite loop when tag is not closed

### DIFF
--- a/src/main/scala/pine/Reader.scala
+++ b/src/main/scala/pine/Reader.scala
@@ -7,6 +7,12 @@ private[pine] class Reader(data: String) {
 
   def rest(): String = data.drop(offset)
 
+  def restAdvance(): String = {
+    val result = data.drop(offset)
+    offset = data.length
+    result
+  }
+
   /** Returns true if `value` matches */
   def lookahead(value: Char): Boolean = data(offset) == value
 

--- a/src/main/scala/pine/internal/HtmlParser.scala
+++ b/src/main/scala/pine/internal/HtmlParser.scala
@@ -94,7 +94,7 @@ object HtmlParser {
     }
 
   def parseText(reader: Reader, xml: Boolean): Option[Text] = {
-    val text = reader.collectUntil('<').getOrElse(reader.rest())
+    val text = reader.collectUntil('<').getOrElse(reader.restAdvance())
     if (text.isEmpty) None
     else Some(Text(HtmlHelpers.decodeText(text, xml)))
   }

--- a/src/test/scala/pine/HtmlParserSpec.scala
+++ b/src/test/scala/pine/HtmlParserSpec.scala
@@ -223,4 +223,12 @@ var x = 42;
       internal.HtmlParser.fromString("<div>editable&&copy</div>", xml = false)
     }
   }
+
+  test("Ignore unclosed tags") {
+    assert(internal.HtmlParser.fromString("<html>", xml = false) == tag.Html)
+    assert(internal.HtmlParser.fromString("<html>\n", xml = false) == tag.Html.set("\n"))
+
+    assert(internal.HtmlParser.fromString("<html>", xml = true) == tag.Html)
+    assert(internal.HtmlParser.fromString("<html>\n", xml = true) == tag.Html.set("\n"))
+  }
 }


### PR DESCRIPTION
When an unclosed tag is followed by a text node, the offset needs to
be advanced. Otherwise, this leads to an infinite loop.