### PR TITLE
Fix Node.removeAll diffing on List of List

### DIFF
--- a/src/main/scala/pine/Node.scala
+++ b/src/main/scala/pine/Node.scala
@@ -79,7 +79,7 @@ case class Tag[TagName <: Singleton](tagName   : String with TagName,
   def remove(node: Node): Tag[TagName] = set(children.diff(List(node)))
   def -(node: Node): Tag[TagName] = remove(node)
 
-  def removeAll(node: List[Node]): Tag[TagName] = set(children.diff(List(node)))
+  def removeAll(nodes: List[Node]): Tag[TagName] = set(children.diff(nodes))
   def --(node: List[Node]): Tag[TagName] = removeAll(node)
 
   def replace(reference: Node, node: Node): Tag[TagName] =

--- a/src/test/scala/pine/NodeSpec.scala
+++ b/src/test/scala/pine/NodeSpec.scala
@@ -350,6 +350,31 @@ class NodeSpec extends FunSuite {
     assert(div.toHtml == """<div class="b a"></div>""")
   }
 
+  test("Remove node") {
+    val rt1 = Tag("div", Map.empty, List(Text("one")))
+    val html = html"""<div class="b a"><div>one</div><div>two</div></div>""".remove(rt1)
+    assert(html.toHtml == """<div class="b a"><div>two</div></div>""")
+  }
+
+  test("Remove non-existing node") {
+    val rt3 = Tag("div", Map.empty, List(Text("three")))
+    val html = html"""<div class="b a"><div>one</div><div>two</div></div>""".remove(rt3)
+    assert(html.toHtml == """<div class="b a"><div>one</div><div>two</div></div>""")
+  }
+
+  test("Remove all nodes") {
+    val rt1 = Tag("div", Map.empty, List(Text("one")))
+    val rt2 = Tag("div", Map.empty, List(Text("two")))
+    val html = html"""<div class="b a"><div>one</div><div>two</div></div>"""
+    val removed = html.removeAll(List(rt1, rt2))
+    assert(removed.toHtml == """<div class="b a"></div>""")
+  }
+
+  test("Remove all nodes (non-existing)") {
+    val div = html"""<div class="b a">text</div>""".removeAll(List(Text("three"), Text("four")))
+    assert(div.toHtml == """<div class="b a">text</div>""")
+  }
+
   test("Encode Long attribute") {
     val input = html"""<input></input>"""
     val updated = input.update { implicit ctx =>


### PR DESCRIPTION
It appears that the following `removeAll` function is incorrectly diffing by wrapping the `List[Node]` parameter in an additional `List`. Currently, this variant `removeAll` does not remove any nodes from the children.
I removed the additional `List`.