### PR TITLE
Build: Update Seed to fix CI failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ kind: pipeline
 name: default
 steps:
   - name: build
-    image: tindzk/seed:0.1.4
+    image: tindzk/seed:0.1.5
     commands:
       - apk add --no-cache yarn
       - yarn add jsdom


### PR DESCRIPTION
The Seed v0.1.4 Docker image ships an outdated Node version which was causing the `jsdom` installation to fail in Drone CI builds:

```
+ yarn add jsdom
yarn add v1.7.0
info No lockfile found.
[1/4] Resolving packages...
warning jsdom > request@2.88.2: request has been deprecated, see request/request#3142
[2/4] Fetching packages...
error data-urls@2.0.0: The engine "node" is incompatible with this module. Expected version ">=10".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```